### PR TITLE
Update simulation rml

### DIFF
--- a/alphacamm-simulations/222RnFromGas.rml
+++ b/alphacamm-simulations/222RnFromGas.rml
@@ -15,10 +15,10 @@
         <parameter name="saveAllEvents" value="false" />
         <parameter name="printProgress" value="true" />
 
-        <generator type="volume" from="gas" > 
-          <source particle="alpha" >
-            <angularDist type="isotropic"/>
-            <energyDist type="mono" energy="5.5" units="MeV" />
+        <generator type="volume" shape="gdml" from="gas">            
+          <source particle="Rn222" fullChain="off">
+              <angular type="isotropic"/>
+              <energy type="mono" energy="0keV"/>
           </source>
         </generator>
 


### PR DESCRIPTION
This PR is related to the one I opened [(#2)](https://github.com/TREX-DM/alphacamm-simulations/pull/2) in the alphacamm-simulations repository (before removing the submodules).

Changes that are implemented (this one is not tracked in this repo):

- Updating the `<detector>` section. Before, we were defining the sensitive volume as `<storage>`. I think both work but this one is more updated.

Keeping the comment on the old PR, I propose some other changes: 
- [ ] Generating the alphas by the decay of each isotope. We can configure via rml if we want to simulate the full chain or stop at some point (https://github.com/rest-for-physics/restG4/pull/132). 
- [ ] If we want to access to the TRestGeant4PhysicsLists object after the simulation, we couldn't because we are naming it as "default". We can ommit the name part `<TRestGeant4PhysicsLists name="default" file="common/physics.xml" />` 
- [ ] Also, a more practical question, do you want to have the rmls divided like they are now or do you prefer to have everything in the same file?
