### PR TITLE
Updating geometry

### DIFF
--- a/alphacamm-geometry/ViewRESTGdml.C
+++ b/alphacamm-geometry/ViewRESTGdml.C
@@ -1,0 +1,46 @@
+void ViewRESTGdml(string filename, float transparency = 50)
+{
+    // first import it and see if there is something wrong with the file
+    // we need TRestGDMLParser to visualize geometries that use external files
+
+    TRestGDMLParser *g = new TRestGDMLParser();
+    //TGeoManager::Import(filename.c_str());
+    //TGeoNode *node = gGeoManager->GetTopNode();
+    TGeoManager *gGeoManager = g->GetGeoManager(filename.c_str());
+    TGeoNode *node = gGeoManager->GetTopNode();
+    // check for overlaps
+    node->CheckOverlaps(0.0001);
+    // print overlaps
+    gGeoManager->PrintOverlaps();
+
+    for (auto i = 0; i < gGeoManager->GetListOfVolumes()->GetEntries(); i++)
+    {
+        TGeoVolume *geoVolume = gGeoManager->GetVolume(i); // https://root.cern/doc/v606/classTGeoVolume.html
+        if (!geoVolume)
+        {
+            continue;
+        }
+        TGeoMaterial *material = geoVolume->GetMaterial();
+        double density = material->GetDensity();
+        string materialName = material->GetName();
+
+        geoVolume->SetTransparency(transparency);
+        if (density < 0.10 /* g/cm3 */)
+        {
+            geoVolume->SetVisibility(kFALSE);
+        }
+    }
+
+    TEveManager::Create();
+
+    auto viewer = gEve->GetDefaultGLViewer();
+    viewer->SetClearColor(0);
+    viewer->SetCurrentCamera(TGLViewer::kCameraPerspXOZ);
+
+    TEveGeoTopNode *top_node = new TEveGeoTopNode(gGeoManager, node);
+    gEve->AddGlobalElement(top_node);
+
+    gEve->FullRedraw3D(kTRUE);
+
+    viewer->CurrentCamera().Reset();
+}

--- a/alphacamm-geometry/geometry.gdml
+++ b/alphacamm-geometry/geometry.gdml
@@ -2,353 +2,29 @@
 <solids>
     <box name="WorldSolid" x="world_size" y="world_size" z="world_size" lunit="mm"/>
     
-    <tube name="vesselSolid" startphi="0" deltaphi="360" rmin="VesselRadius-vessel_thickness" rmax="VesselRadius" z="VesselLength" aunit="deg" lunit="mm" />
-
-    <tube name="gasSolid1" startphi="0" deltaphi="360" rmin="0" rmax="VesselRadius-vessel_thickness" z="gas_length" aunit="deg" lunit="mm" />
-
-    <tube name="bottomSolid1" startphi="0" deltaphi="360" rmin="0" rmax="VesselRadius-vessel_thickness" z="vessel_thickness" aunit="deg" lunit="mm" />
-
-    <tube name="windowSolid0" startphi="0" deltaphi="360" rmin="0" rmax="VesselRadius-vessel_thickness" z="window_thickness" aunit="deg" lunit="mm" />
-
-    <box name="windowHole" x="windowXSize" y="windowYSize" z="window_thickness" lunit="mm"/>
-
-    <box name="wireX" x="windowXSize" y="cathode_square_width" z="window_thickness" lunit="mm"/>
-    <box name="wireY" x="cathode_square_width" y="windowYSize" z="window_thickness" lunit="mm"/>
-
-    <box name="mylarSolid" x="windowXSize" y="windowYSize" z="mylar_thickness" lunit="mm"/> 
-
     <box name="readoutSolid" x="readout_size" y="readout_size" z="readout_thickness" lunit="mm"/>
- 
-    <tube name="upperVesselSolid" startphi="0" deltaphi="360" rmin="VesselRadius-vessel_thickness" rmax="VesselRadius" z="UpperVesselLength" aunit="deg" lunit="mm" />
+    
+    <tube name="vesselSolid" startphi="0" deltaphi="360" rmin="vessel_radius" rmax="vessel_radius+vessel_thickness*2" z="vessel_inner_length" aunit="deg" lunit="mm"/>
+  
+    <tube name="vesselBottomcoverSolid" startphi="0" deltaphi="360" rmin="0" rmax="vessel_radius+vessel_thickness*2" z="vessel_thickness" aunit="deg" lunit="mm"/>
 
-    <tube name="gasUpperSolid1" startphi="0" deltaphi="360" rmin="0" rmax="VesselRadius-vessel_thickness" z="gasUpperVesselLength" aunit="deg" lunit="mm" />
+    <tube name="vesselTopcoverAuxSolid" startphi="0" deltaphi="360" rmin="0" rmax="vessel_radius+vessel_thickness*2" z="vessel_thickness" aunit="deg" lunit="mm"/>
 
-    <tube name="coverVesselSolid" startphi="0" deltaphi="360" rmin="0" rmax="VesselRadius -vessel_thickness" z="vessel_thickness" aunit="deg" lunit="mm" />
-
- <!-- The  vessel -->
-
-       	<subtraction name="bottomSolid">
-            <first ref="bottomSolid1"/>
+    <subtraction name="vesselTopcoverSolid">
+            <first ref="vesselTopcoverAuxSolid"/>
             <second ref="readoutSolid"/>
-	    <position name="bottomSub" unit="mm" x="0" y="0" z="vessel_thickness*0.5-readout_thickness*0.5"/>
-       </subtraction>
+	    <position name="vesselcoverSub.position" z="-0.5*vessel_thickness+0.5*readout_thickness" unit="mm"/>
+    </subtraction>
 
-<!-- The cathode : To do substract cathode window-->
+    <tube name="gasSolid" startphi="0" deltaphi="360" rmin="0" rmax="vessel_radius" z="gas_length" aunit="deg" lunit="mm"/>
+    <tube name="gasbelowAuxSolid" startphi="0" deltaphi="360" rmin="0" rmax="vessel_radius" z="gas_below_length" aunit="deg" lunit="mm"/>
+    <tube name="cathodeSolid" startphi="0" deltaphi="360" rmin="0" rmax="cathode_radius" z="cathode_thickness" aunit="deg" lunit="mm"/>
 
-      <subtraction name="windowSolid1">
-            <first ref="windowSolid0"/>
-            <second ref="windowHole"/>
-	    <positionref ref="null_position"/>
-      </subtraction>
-
-   <!-- Add X wires-->
-
-      <union name="windowSolid2" >
-        <first ref="windowSolid1" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_01r" />
-       </union>
-       
-       <union name="windowSolid3" >
-        <first ref="windowSolid2" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_01l" />
-       </union>
-       
-       <union name="windowSolid4" >
-        <first ref="windowSolid3" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_02r" />
-       </union>
-       
-       <union name="windowSolid5" >
-        <first ref="windowSolid4" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_02l" />
-       </union>
-       
-       <union name="windowSolid6" >
-        <first ref="windowSolid5" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_03r" />
-       </union>
-       
-       <union name="windowSolid7" >
-        <first ref="windowSolid6" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_03l" />
-       </union>
-       
-       <union name="windowSolid8" >
-        <first ref="windowSolid7" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_04r" />
-       </union>
-       
-       <union name="windowSolid9" >
-        <first ref="windowSolid8" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_04l" />
-       </union>
-       
-       <union name="windowSolid10" >
-        <first ref="windowSolid9" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_05r" />
-       </union>
-       
-       <union name="windowSolid11" >
-        <first ref="windowSolid10" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_05l" />
-       </union>
-       
-       <union name="windowSolid12" >
-        <first ref="windowSolid11" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_06r" />
-       </union>
-
-      <union name="windowSolid13" >
-        <first ref="windowSolid12" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_06l" />
-       </union>
-       
-       <union name="windowSolid14" >
-        <first ref="windowSolid13" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_07r" />
-       </union>
-       
-       <union name="windowSolid15" >
-        <first ref="windowSolid14" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_07l" />
-       </union>
-       
-       <union name="windowSolid16" >
-        <first ref="windowSolid15" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_08r" />
-       </union>
-       
-       <union name="windowSolid17" >
-        <first ref="windowSolid16" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_08l" />
-       </union>
-       
-       <union name="windowSolid18" >
-        <first ref="windowSolid17" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_09r" />
-       </union>
-       
-       <union name="windowSolid19" >
-        <first ref="windowSolid18" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_09l" />
-       </union>
-       
-       <union name="windowSolid20" >
-        <first ref="windowSolid19" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_10r" />
-       </union>
-       
-       <union name="windowSolid21" >
-        <first ref="windowSolid20" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_10l" />
-       </union>
-       
-       <union name="windowSolid22" >
-        <first ref="windowSolid21" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_11r" />
-       </union>
-       
-       <union name="windowSolid23" >
-        <first ref="windowSolid22" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_11l" />
-       </union>
-
-     <union name="windowSolid24" >
-        <first ref="windowSolid23" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_12r" />
-       </union>
-       
-       <union name="windowSolid25" >
-        <first ref="windowSolid24" />
-        <second ref="wireX" />
-        <positionref ref="wirey_position_12l" />
-       </union>
-
-  <!-- Add Y wires-->
-
-     <union name="windowSolid26" >
-        <first ref="windowSolid25" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_01r" />
-       </union>
-
-     <union name="windowSolid27" >
-        <first ref="windowSolid26" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_01l" />
-       </union>
-
-
-     <union name="windowSolid28" >
-        <first ref="windowSolid27" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_02r" />
-       </union>
-       
-      <union name="windowSolid29" >
-        <first ref="windowSolid28" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_02l" />
-       </union>
-       
-      <union name="windowSolid30" >
-        <first ref="windowSolid29" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_03r" />
-       </union>
-       
-      <union name="windowSolid31" >
-        <first ref="windowSolid30" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_03l" />
-       </union>
-       
-      <union name="windowSolid32" >
-        <first ref="windowSolid31" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_04r" />
-       </union>
-       
-      <union name="windowSolid33" >
-        <first ref="windowSolid32" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_04l" />
-       </union>
-       
-      <union name="windowSolid34" >
-        <first ref="windowSolid33" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_05r" />
-       </union>
-       
-       <union name="windowSolid35" >
-        <first ref="windowSolid34" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_05l" />
-       </union>
-       
-      <union name="windowSolid36" >
-        <first ref="windowSolid35" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_06r" />
-       </union>
-       
-      <union name="windowSolid37" >
-        <first ref="windowSolid36" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_06l" />
-       </union>
-       
-      <union name="windowSolid38" >
-        <first ref="windowSolid37" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_07r" />
-       </union>
-       
-      <union name="windowSolid39" >
-        <first ref="windowSolid38" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_07l" />
-       </union>
-       
-      <union name="windowSolid40" >
-        <first ref="windowSolid39" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_08r" />
-       </union>
-       
-      <union name="windowSolid41" >
-        <first ref="windowSolid40" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_08l" />
-       </union>
-       
-      <union name="windowSolid42" >
-        <first ref="windowSolid41" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_09r" />
-       </union>
-       
-       <union name="windowSolid43" >
-        <first ref="windowSolid42" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_09l" />
-       </union>
-       
-       <union name="windowSolid44" >
-        <first ref="windowSolid43" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_10r" />
-       </union>
-       
-       <union name="windowSolid45" >
-        <first ref="windowSolid44" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_10l" />
-       </union>
-       
-       <union name="windowSolid46" >
-        <first ref="windowSolid45" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_11r" />
-       </union>
-
-       <union name="windowSolid47" >
-        <first ref="windowSolid46" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_11l" />
-       </union>
-       
-       <union name="windowSolid48" >
-        <first ref="windowSolid47" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_12r" />
-       </union>
-
-       <union name="windowSolid" >
-        <first ref="windowSolid48" />
-        <second ref="wireY" />
-        <positionref ref="wirex_position_12l" />
-       </union>
-
-<!-- BottomVessel -->
-
-      <subtraction name="gasSolid">
-            <first ref="gasSolid1"/>
-            <second ref="windowSolid"/>
-	    <position name="gasSub1" unit="mm" x="0" y="0" z="0.5*gas_length - 0.5*window_thickness"/>
-       </subtraction>
-
-<!-- UpperVessel -->
-
-        <subtraction name="gasUpperSolid">
-            <first ref="gasUpperSolid1"/>
-            <second ref="mylarSolid"/>
-	    <position name="gasSub2" unit="mm" x="0" y="0" z="-0.5*gasUpperVesselLength + 0.5*mylar_thickness"/>
-       </subtraction>
+    <subtraction name="gasbelowSolid">
+            <first ref="gasbelowAuxSolid"/>
+            <second ref="cathodeSolid"/>
+	    <position name="gasbelowcathodeSub.position" z="gas_below_length*0.5-cathode_thickness*0.5" unit="mm"/>
+    </subtraction>
 
 </solids>
 
@@ -356,9 +32,32 @@
 
    <!-- {{{ Volumes definition (material and solid assignment) -->
 
+    <!--Gas (sensitive)-->
     <volume name="gasVolume">
         <materialref ref="Ar_ISO"/>
         <solidref ref="gasSolid"/>
+    </volume>
+
+    <!--Gas (below cathode)-->
+    <volume name="gasbelowVolume">
+        <materialref ref="Ar_ISO"/>
+        <solidref ref="gasbelowSolid"/>
+    </volume>
+
+    <!--Vessel and covers -->
+    <volume name="vesselVolume">
+        <materialref ref="Copper"/>
+        <solidref ref="vesselSolid"/>
+    </volume>
+
+    <volume name="vesselTopcoverVolume">
+        <materialref ref="Copper"/>
+        <solidref ref="vesselTopcoverSolid"/>
+    </volume>
+
+    <volume name="vesselBottomcoverVolume">
+        <materialref ref="Copper"/>
+        <solidref ref="vesselBottomcoverSolid"/>
     </volume>
 
     <volume name="vesselVolume">
@@ -366,42 +65,13 @@
         <solidref ref="vesselSolid"/>
     </volume>
 
-    <volume name="bottomVolume">
-        <materialref ref="Copper"/>
-        <solidref ref="bottomSolid"/>
-    </volume>
-
-   <!-- Upper  vessel -->
-
-    <volume name="gasUpperVolume">
-        <materialref ref="Air"/>
-        <solidref ref="gasUpperSolid"/>
-    </volume>
-
-    <volume name="upperVesselVolume">
-        <materialref ref="Copper"/>
-        <solidref ref="upperVesselSolid"/>
-    </volume>
-
-    <volume name="coverVolume">
-        <materialref ref="Copper"/>
-        <solidref ref="coverVesselSolid"/>
-    </volume>
-
    <!-- Cathode/Window -->
-
-    <volume name="mylarVolume">
-        <materialref ref="Mylar"/>
-        <solidref ref="mylarSolid"/>
-    </volume>
-
-       <volume name="windowVolume">
+    <volume name="cathodeVolume">
         <materialref ref="Copper"/>
-        <solidref ref="windowSolid"/>
+        <solidref ref="cathodeSolid"/>
     </volume>
 
    <!-- Readout -->
-
     <volume name="readoutVolume">
         <materialref ref="Copper"/>
         <solidref ref="readoutSolid"/>
@@ -411,54 +81,43 @@
 
     <!-- {{{ Physical volume definition (volume and position assignment) -->
 
- 
-        <volume name="World">
+    <volume name="World">
         <materialref ref="Air"/>
         <solidref ref="WorldSolid"/>
 
-        <physvol name="vessel">
-            <volumeref ref="vesselVolume"/>
-            <position name="vesselPosition" unit="mm" x="0" y="0" z="0.5*VesselLength"/>
+        <physvol name="vesselTopcover">
+            <volumeref ref="vesselTopcoverVolume"/>
+            <position name="vesselTopcover.position" z="vesselTopcover_ZPosition" unit="mm"/>
         </physvol>
 
-        <physvol name="bottom">
-            <volumeref ref="bottomVolume"/>
-            <position name="bottomPosition" unit="mm" x="0" y="0" z="vessel_thickness*0.5"/>
+       <physvol name="readout">
+            <volumeref ref="readoutVolume"/>
+            <position name="readout.position" z="readout_ZPosition" unit="mm"/>
         </physvol>
 
         <physvol name="gas">
             <volumeref ref="gasVolume"/>
-            <position name="gasPosition" unit="mm" x="0" y="0" z="0.5*gas_length+vessel_thickness"/>
-        </physvol>
-        
-        <physvol name="cover">
-            <volumeref ref="coverVolume"/>
-            <position name="coverPosition" unit="mm" x="0" y="0" z="VesselLength+UpperVesselLength-0.5*vessel_thickness"/>
+            <position name="gas.position" z="0" unit="mm"/>
         </physvol>
         
         <physvol name="cathode">
-            <volumeref ref="windowVolume"/>
-            <positionref ref="window_position"/>
+            <volumeref ref="cathodeVolume"/>
+            <position name="cathode.position" z="cathode_ZPosition" unit="mm"/>
         </physvol>
 
-       <physvol name="mylar">
-            <volumeref ref="mylarVolume"/>
-            <positionref ref="mylar_position"/>
+        <physvol name="gasbelow">
+            <volumeref ref="gasbelowVolume"/>
+            <position name="gasbelow.position" z="gasbelow_ZPosition" unit="mm"/>
         </physvol>
 
-         <physvol name="readout">
-            <volumeref ref="readoutVolume"/>
-            <positionref ref="readout_position"/>
+        <physvol name="vesselBottomcover">
+            <volumeref ref="vesselBottomcoverVolume"/>
+            <position name="vesselBottomcover.position" z="vesselBottomcover_ZPosition" unit="mm"/>
         </physvol>
 
-        <physvol name="gas2">
-            <volumeref ref="gasUpperVolume"/>
-            <position name="gasUpperPosition" unit="mm" x="0" y="0" z="VesselLength+0.5*gasUpperVesselLength"/>
-        </physvol>
-
-        <physvol name="vessel2">
-            <volumeref ref="upperVesselVolume"/>
-            <position name="upperVesselPosition" unit="mm" x="0" y="0" z="VesselLength+0.5*UpperVesselLength"/>
+        <physvol name="vessel">
+            <volumeref ref="vesselVolume"/>
+            <position name="vessel.position" z="vessel_ZPosition" unit="mm"/>
         </physvol>
 
    </volume>

--- a/alphacamm-geometry/geometry.gdml
+++ b/alphacamm-geometry/geometry.gdml
@@ -30,7 +30,7 @@
        	<subtraction name="bottomSolid">
             <first ref="bottomSolid1"/>
             <second ref="readoutSolid"/>
-	    <position name="bottomSub"  x="0" y="0" z="vessel_thickness*0.5-readout_thickness*0.5"/>
+	    <position name="bottomSub" unit="mm" x="0" y="0" z="vessel_thickness*0.5-readout_thickness*0.5"/>
        </subtraction>
 
 <!-- The cathode : To do substract cathode window-->
@@ -339,7 +339,7 @@
       <subtraction name="gasSolid">
             <first ref="gasSolid1"/>
             <second ref="windowSolid"/>
-	    <position name="gasSub1"  x="0" y="0" z="0.5*gas_length - 0.5*window_thickness"/>
+	    <position name="gasSub1" unit="mm" x="0" y="0" z="0.5*gas_length - 0.5*window_thickness"/>
        </subtraction>
 
 <!-- UpperVessel -->
@@ -347,7 +347,7 @@
         <subtraction name="gasUpperSolid">
             <first ref="gasUpperSolid1"/>
             <second ref="mylarSolid"/>
-	    <position name="gasSub2"  x="0" y="0" z="-0.5*gasUpperVesselLength + 0.5*mylar_thickness"/>
+	    <position name="gasSub2" unit="mm" x="0" y="0" z="-0.5*gasUpperVesselLength + 0.5*mylar_thickness"/>
        </subtraction>
 
 </solids>
@@ -418,22 +418,22 @@
 
         <physvol name="vessel">
             <volumeref ref="vesselVolume"/>
-            <position name="vesselPosition"  x="0" y="0" z="0.5*VesselLength"/>
+            <position name="vesselPosition" unit="mm" x="0" y="0" z="0.5*VesselLength"/>
         </physvol>
 
         <physvol name="bottom">
             <volumeref ref="bottomVolume"/>
-            <position name="bottomPosition"  x="0" y="0" z="vessel_thickness*0.5"/>
+            <position name="bottomPosition" unit="mm" x="0" y="0" z="vessel_thickness*0.5"/>
         </physvol>
 
         <physvol name="gas">
             <volumeref ref="gasVolume"/>
-            <position name="gasPosition"  x="0" y="0" z="0.5*gas_length+vessel_thickness"/>
+            <position name="gasPosition" unit="mm" x="0" y="0" z="0.5*gas_length+vessel_thickness"/>
         </physvol>
         
         <physvol name="cover">
             <volumeref ref="coverVolume"/>
-            <position name="coverPosition"  x="0" y="0" z="VesselLength+UpperVesselLength-0.5*vessel_thickness"/>
+            <position name="coverPosition" unit="mm" x="0" y="0" z="VesselLength+UpperVesselLength-0.5*vessel_thickness"/>
         </physvol>
         
         <physvol name="cathode">
@@ -453,12 +453,12 @@
 
         <physvol name="gas2">
             <volumeref ref="gasUpperVolume"/>
-            <position name="gasUpperPosition"  x="0" y="0" z="VesselLength+0.5*gasUpperVesselLength"/>
+            <position name="gasUpperPosition" unit="mm" x="0" y="0" z="VesselLength+0.5*gasUpperVesselLength"/>
         </physvol>
 
         <physvol name="vessel2">
             <volumeref ref="upperVesselVolume"/>
-            <position name="upperVesselPosition"  x="0" y="0" z="VesselLength+0.5*UpperVesselLength"/>
+            <position name="upperVesselPosition" unit="mm" x="0" y="0" z="VesselLength+0.5*UpperVesselLength"/>
         </physvol>
 
    </volume>

--- a/alphacamm-geometry/geometry.gdml
+++ b/alphacamm-geometry/geometry.gdml
@@ -97,7 +97,7 @@
 
         <physvol name="gas">
             <volumeref ref="gasVolume"/>
-            <position name="gas.position" z="0" unit="mm"/>
+            <position name="gas.position" z="gas_ZPosition" unit="mm"/>
         </physvol>
         
         <physvol name="cathode">

--- a/alphacamm-geometry/geometry.gdml
+++ b/alphacamm-geometry/geometry.gdml
@@ -26,16 +26,26 @@
 	    <position name="gasbelowcathodeSub.position" z="gas_below_length*0.5-cathode_thickness*0.5" unit="mm"/>
     </subtraction>
 
+    <box name="sampleSolid" x="sampleXSize" y="sampleYSize" z="sample_thickness" lunit="mm"/>
 </solids>
 
 <structure>
 
    <!-- {{{ Volumes definition (material and solid assignment) -->
 
+    <volume name="sampleVolume">
+        <materialref  ref="G4_TEFLON"/>
+        <solidref ref="sampleSolid"/>
+    </volume>
+
     <!--Gas (sensitive)-->
     <volume name="gasVolume">
         <materialref ref="Ar_ISO"/>
         <solidref ref="gasSolid"/>
+        <physvol name="sample">
+            <volumeref ref="sampleVolume"/> <!--sample inside the gas-->
+            <position name="sample.position" z="sample_ZPosition" unit="mm"/>
+        </physvol>
     </volume>
 
     <!--Gas (below cathode)-->

--- a/alphacamm-geometry/old/geometry.gdml
+++ b/alphacamm-geometry/old/geometry.gdml
@@ -1,0 +1,467 @@
+
+<solids>
+    <box name="WorldSolid" x="world_size" y="world_size" z="world_size" lunit="mm"/>
+    
+    <tube name="vesselSolid" startphi="0" deltaphi="360" rmin="VesselRadius-vessel_thickness" rmax="VesselRadius" z="VesselLength" aunit="deg" lunit="mm" />
+
+    <tube name="gasSolid1" startphi="0" deltaphi="360" rmin="0" rmax="VesselRadius-vessel_thickness" z="gas_length" aunit="deg" lunit="mm" />
+
+    <tube name="bottomSolid1" startphi="0" deltaphi="360" rmin="0" rmax="VesselRadius-vessel_thickness" z="vessel_thickness" aunit="deg" lunit="mm" />
+
+    <tube name="windowSolid0" startphi="0" deltaphi="360" rmin="0" rmax="VesselRadius-vessel_thickness" z="window_thickness" aunit="deg" lunit="mm" />
+
+    <box name="windowHole" x="windowXSize" y="windowYSize" z="window_thickness" lunit="mm"/>
+
+    <box name="wireX" x="windowXSize" y="cathode_square_width" z="window_thickness" lunit="mm"/>
+    <box name="wireY" x="cathode_square_width" y="windowYSize" z="window_thickness" lunit="mm"/>
+
+    <box name="mylarSolid" x="windowXSize" y="windowYSize" z="mylar_thickness" lunit="mm"/> 
+
+    <box name="readoutSolid" x="readout_size" y="readout_size" z="readout_thickness" lunit="mm"/>
+ 
+    <tube name="upperVesselSolid" startphi="0" deltaphi="360" rmin="VesselRadius-vessel_thickness" rmax="VesselRadius" z="UpperVesselLength" aunit="deg" lunit="mm" />
+
+    <tube name="gasUpperSolid1" startphi="0" deltaphi="360" rmin="0" rmax="VesselRadius-vessel_thickness" z="gasUpperVesselLength" aunit="deg" lunit="mm" />
+
+    <tube name="coverVesselSolid" startphi="0" deltaphi="360" rmin="0" rmax="VesselRadius -vessel_thickness" z="vessel_thickness" aunit="deg" lunit="mm" />
+
+ <!-- The  vessel -->
+
+       	<subtraction name="bottomSolid">
+            <first ref="bottomSolid1"/>
+            <second ref="readoutSolid"/>
+	    <position name="bottomSub" unit="mm" x="0" y="0" z="vessel_thickness*0.5-readout_thickness*0.5"/>
+       </subtraction>
+
+<!-- The cathode : To do substract cathode window-->
+
+      <subtraction name="windowSolid1">
+            <first ref="windowSolid0"/>
+            <second ref="windowHole"/>
+	    <positionref ref="null_position"/>
+      </subtraction>
+
+   <!-- Add X wires-->
+
+      <union name="windowSolid2" >
+        <first ref="windowSolid1" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_01r" />
+       </union>
+       
+       <union name="windowSolid3" >
+        <first ref="windowSolid2" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_01l" />
+       </union>
+       
+       <union name="windowSolid4" >
+        <first ref="windowSolid3" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_02r" />
+       </union>
+       
+       <union name="windowSolid5" >
+        <first ref="windowSolid4" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_02l" />
+       </union>
+       
+       <union name="windowSolid6" >
+        <first ref="windowSolid5" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_03r" />
+       </union>
+       
+       <union name="windowSolid7" >
+        <first ref="windowSolid6" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_03l" />
+       </union>
+       
+       <union name="windowSolid8" >
+        <first ref="windowSolid7" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_04r" />
+       </union>
+       
+       <union name="windowSolid9" >
+        <first ref="windowSolid8" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_04l" />
+       </union>
+       
+       <union name="windowSolid10" >
+        <first ref="windowSolid9" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_05r" />
+       </union>
+       
+       <union name="windowSolid11" >
+        <first ref="windowSolid10" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_05l" />
+       </union>
+       
+       <union name="windowSolid12" >
+        <first ref="windowSolid11" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_06r" />
+       </union>
+
+      <union name="windowSolid13" >
+        <first ref="windowSolid12" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_06l" />
+       </union>
+       
+       <union name="windowSolid14" >
+        <first ref="windowSolid13" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_07r" />
+       </union>
+       
+       <union name="windowSolid15" >
+        <first ref="windowSolid14" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_07l" />
+       </union>
+       
+       <union name="windowSolid16" >
+        <first ref="windowSolid15" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_08r" />
+       </union>
+       
+       <union name="windowSolid17" >
+        <first ref="windowSolid16" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_08l" />
+       </union>
+       
+       <union name="windowSolid18" >
+        <first ref="windowSolid17" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_09r" />
+       </union>
+       
+       <union name="windowSolid19" >
+        <first ref="windowSolid18" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_09l" />
+       </union>
+       
+       <union name="windowSolid20" >
+        <first ref="windowSolid19" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_10r" />
+       </union>
+       
+       <union name="windowSolid21" >
+        <first ref="windowSolid20" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_10l" />
+       </union>
+       
+       <union name="windowSolid22" >
+        <first ref="windowSolid21" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_11r" />
+       </union>
+       
+       <union name="windowSolid23" >
+        <first ref="windowSolid22" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_11l" />
+       </union>
+
+     <union name="windowSolid24" >
+        <first ref="windowSolid23" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_12r" />
+       </union>
+       
+       <union name="windowSolid25" >
+        <first ref="windowSolid24" />
+        <second ref="wireX" />
+        <positionref ref="wirey_position_12l" />
+       </union>
+
+  <!-- Add Y wires-->
+
+     <union name="windowSolid26" >
+        <first ref="windowSolid25" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_01r" />
+       </union>
+
+     <union name="windowSolid27" >
+        <first ref="windowSolid26" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_01l" />
+       </union>
+
+
+     <union name="windowSolid28" >
+        <first ref="windowSolid27" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_02r" />
+       </union>
+       
+      <union name="windowSolid29" >
+        <first ref="windowSolid28" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_02l" />
+       </union>
+       
+      <union name="windowSolid30" >
+        <first ref="windowSolid29" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_03r" />
+       </union>
+       
+      <union name="windowSolid31" >
+        <first ref="windowSolid30" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_03l" />
+       </union>
+       
+      <union name="windowSolid32" >
+        <first ref="windowSolid31" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_04r" />
+       </union>
+       
+      <union name="windowSolid33" >
+        <first ref="windowSolid32" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_04l" />
+       </union>
+       
+      <union name="windowSolid34" >
+        <first ref="windowSolid33" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_05r" />
+       </union>
+       
+       <union name="windowSolid35" >
+        <first ref="windowSolid34" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_05l" />
+       </union>
+       
+      <union name="windowSolid36" >
+        <first ref="windowSolid35" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_06r" />
+       </union>
+       
+      <union name="windowSolid37" >
+        <first ref="windowSolid36" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_06l" />
+       </union>
+       
+      <union name="windowSolid38" >
+        <first ref="windowSolid37" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_07r" />
+       </union>
+       
+      <union name="windowSolid39" >
+        <first ref="windowSolid38" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_07l" />
+       </union>
+       
+      <union name="windowSolid40" >
+        <first ref="windowSolid39" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_08r" />
+       </union>
+       
+      <union name="windowSolid41" >
+        <first ref="windowSolid40" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_08l" />
+       </union>
+       
+      <union name="windowSolid42" >
+        <first ref="windowSolid41" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_09r" />
+       </union>
+       
+       <union name="windowSolid43" >
+        <first ref="windowSolid42" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_09l" />
+       </union>
+       
+       <union name="windowSolid44" >
+        <first ref="windowSolid43" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_10r" />
+       </union>
+       
+       <union name="windowSolid45" >
+        <first ref="windowSolid44" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_10l" />
+       </union>
+       
+       <union name="windowSolid46" >
+        <first ref="windowSolid45" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_11r" />
+       </union>
+
+       <union name="windowSolid47" >
+        <first ref="windowSolid46" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_11l" />
+       </union>
+       
+       <union name="windowSolid48" >
+        <first ref="windowSolid47" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_12r" />
+       </union>
+
+       <union name="windowSolid" >
+        <first ref="windowSolid48" />
+        <second ref="wireY" />
+        <positionref ref="wirex_position_12l" />
+       </union>
+
+<!-- BottomVessel -->
+
+      <subtraction name="gasSolid">
+            <first ref="gasSolid1"/>
+            <second ref="windowSolid"/>
+	    <position name="gasSub1" unit="mm" x="0" y="0" z="0.5*gas_length - 0.5*window_thickness"/>
+       </subtraction>
+
+<!-- UpperVessel -->
+
+        <subtraction name="gasUpperSolid">
+            <first ref="gasUpperSolid1"/>
+            <second ref="mylarSolid"/>
+	    <position name="gasSub2" unit="mm" x="0" y="0" z="-0.5*gasUpperVesselLength + 0.5*mylar_thickness"/>
+       </subtraction>
+
+</solids>
+
+<structure>
+
+   <!-- {{{ Volumes definition (material and solid assignment) -->
+
+    <volume name="gasVolume">
+        <materialref ref="Ar_ISO"/>
+        <solidref ref="gasSolid"/>
+    </volume>
+
+    <volume name="vesselVolume">
+        <materialref ref="Copper"/>
+        <solidref ref="vesselSolid"/>
+    </volume>
+
+    <volume name="bottomVolume">
+        <materialref ref="Copper"/>
+        <solidref ref="bottomSolid"/>
+    </volume>
+
+   <!-- Upper  vessel -->
+
+    <volume name="gasUpperVolume">
+        <materialref ref="Air"/>
+        <solidref ref="gasUpperSolid"/>
+    </volume>
+
+    <volume name="upperVesselVolume">
+        <materialref ref="Copper"/>
+        <solidref ref="upperVesselSolid"/>
+    </volume>
+
+    <volume name="coverVolume">
+        <materialref ref="Copper"/>
+        <solidref ref="coverVesselSolid"/>
+    </volume>
+
+   <!-- Cathode/Window -->
+
+    <volume name="mylarVolume">
+        <materialref ref="Mylar"/>
+        <solidref ref="mylarSolid"/>
+    </volume>
+
+       <volume name="windowVolume">
+        <materialref ref="Copper"/>
+        <solidref ref="windowSolid"/>
+    </volume>
+
+   <!-- Readout -->
+
+    <volume name="readoutVolume">
+        <materialref ref="Copper"/>
+        <solidref ref="readoutSolid"/>
+    </volume>
+
+    <!-- }}} -->
+
+    <!-- {{{ Physical volume definition (volume and position assignment) -->
+
+ 
+        <volume name="World">
+        <materialref ref="Air"/>
+        <solidref ref="WorldSolid"/>
+
+        <physvol name="vessel">
+            <volumeref ref="vesselVolume"/>
+            <position name="vesselPosition" unit="mm" x="0" y="0" z="0.5*VesselLength"/>
+        </physvol>
+
+        <physvol name="bottom">
+            <volumeref ref="bottomVolume"/>
+            <position name="bottomPosition" unit="mm" x="0" y="0" z="vessel_thickness*0.5"/>
+        </physvol>
+
+        <physvol name="gas">
+            <volumeref ref="gasVolume"/>
+            <position name="gasPosition" unit="mm" x="0" y="0" z="0.5*gas_length+vessel_thickness"/>
+        </physvol>
+        
+        <physvol name="cover">
+            <volumeref ref="coverVolume"/>
+            <position name="coverPosition" unit="mm" x="0" y="0" z="VesselLength+UpperVesselLength-0.5*vessel_thickness"/>
+        </physvol>
+        
+        <physvol name="cathode">
+            <volumeref ref="windowVolume"/>
+            <positionref ref="window_position"/>
+        </physvol>
+
+       <physvol name="mylar">
+            <volumeref ref="mylarVolume"/>
+            <positionref ref="mylar_position"/>
+        </physvol>
+
+         <physvol name="readout">
+            <volumeref ref="readoutVolume"/>
+            <positionref ref="readout_position"/>
+        </physvol>
+
+        <physvol name="gas2">
+            <volumeref ref="gasUpperVolume"/>
+            <position name="gasUpperPosition" unit="mm" x="0" y="0" z="VesselLength+0.5*gasUpperVesselLength"/>
+        </physvol>
+
+        <physvol name="vessel2">
+            <volumeref ref="upperVesselVolume"/>
+            <position name="upperVesselPosition" unit="mm" x="0" y="0" z="VesselLength+0.5*UpperVesselLength"/>
+        </physvol>
+
+   </volume>
+    <!-- }}} -->
+
+</structure>

--- a/alphacamm-geometry/old/setup.gdml
+++ b/alphacamm-geometry/old/setup.gdml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+
+<!DOCTYPE gdml [
+<!ENTITY geometry SYSTEM "geometry.gdml">
+<!ENTITY materials SYSTEM "https://rest-for-physics.github.io/materials/rest.xml">
+]>
+
+
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+
+<!-- Definition of global variables -->
+<!-- All values should be in mm -->
+
+     <define>
+       <variable name="world_size" value="20000" />
+       <!-- The TPC gas target -->
+       <variable name="targetGasDensity" value="1.61"/>
+       <variable name="quencherFraction" value="0.02"/>
+       <variable name="quencherDensity" value="0.01"/>
+       <variable name="gasTemperature" value="300"/> <!-- K -->
+       <variable name="gasPressure" value="1.05"/> <!-- bar -->
+
+       <!-- vessel definitions -->
+
+        <constant name="vessel_thickness" value="5" />   <!--in mm's -->
+		<constant name="VesselRadius" value="193" />
+		<constant name="VesselLength" value="110" />
+
+		<!-- Micromegas variables -->
+
+    	<constant name="readout_thickness" value="1"/>
+        <constant name="readout_size" value="250"/>
+
+        <!--Window/Cathode on top of the chamber  -->
+
+		<constant name="mylar_thickness" value="0.002"/>
+        <constant name="windowXSize" value="250"/>
+        <constant name="windowYSize" value="250"/>
+        <constant name="window_thickness" value="5"/>
+		<constant name="cathode_square_size" value="10"/>
+		<constant name="cathode_square_width" value="0.1"/>
+
+        <position name="wirey_position_01r" unit="mm" x="0"  y="cathode_square_size*0.5" z="0"/>
+		<position name="wirey_position_02r" unit="mm" x="0"  y="cathode_square_size*1.5" z="0"/>
+		<position name="wirey_position_03r" unit="mm" x="0" y="cathode_square_size*2.5" z="0"/>
+		<position name="wirey_position_04r" unit="mm" x="0" y="cathode_square_size*3.5" z="0" />
+		<position name="wirey_position_05r" unit="mm" x="0" y="cathode_square_size*4.5" z="0"/>
+		<position name="wirey_position_06r" unit="mm" x="0" y="cathode_square_size*5.5" z="0"/>
+		<position name="wirey_position_07r" unit="mm" x="0" y="cathode_square_size*6.5" z="0"/>
+		<position name="wirey_position_08r" unit="mm" x="0" y="cathode_square_size*7.5" z="0"/>
+		<position name="wirey_position_09r" unit="mm" x="0" y="cathode_square_size*8.5" z="0"/>
+		<position name="wirey_position_10r" unit="mm" x="0" y="cathode_square_size*9.5" z="0"/>
+		<position name="wirey_position_11r" unit="mm" x="0" y="cathode_square_size*10.5" z="0"/>
+		<position name="wirey_position_12r" unit="mm" x="0" y="cathode_square_size*11.5" z="0"/>
+        <position name="wirey_position_01l" unit="mm" x="0" y="-cathode_square_size*0.5" z="0"/>
+		<position name="wirey_position_02l" unit="mm" x="0" y="-cathode_square_size*1.5" z="0"/>
+		<position name="wirey_position_03l" unit="mm" x="0" y="-cathode_square_size*2.5" z="0"/>
+		<position name="wirey_position_04l" unit="mm" x="0" y="-cathode_square_size*3.5" z="0"/>
+		<position name="wirey_position_05l" unit="mm" x="0" y="-cathode_square_size*4.5" z="0"/>
+		<position name="wirey_position_06l" unit="mm" x="0" y="-cathode_square_size*5.5" z="0"/>
+		<position name="wirey_position_07l" unit="mm" x="0" y="-cathode_square_size*6.5" z="0"/>
+		<position name="wirey_position_08l" unit="mm" x="0" y="-cathode_square_size*7.5" z="0"/>
+		<position name="wirey_position_09l" unit="mm" x="0" y="-cathode_square_size*8.5" z="0"/>
+		<position name="wirey_position_10l" unit="mm" x="0" y="-cathode_square_size*9.5" z="0"/>
+		<position name="wirey_position_11l" unit="mm" x="0" y="-cathode_square_size*10.5" z="0"/>
+		<position name="wirey_position_12l" unit="mm" x="0" y="-cathode_square_size*11.5" z="0"/>
+	
+		<position name="wirex_position_01r" unit="mm" x="cathode_square_size*0.5"  y="0" z="0"/>
+		<position name="wirex_position_02r" unit="mm" x="cathode_square_size*1.5"  y="0" z="0"/>
+		<position name="wirex_position_03r" unit="mm" x="cathode_square_size*2.5" y="0" z="0"/>
+		<position name="wirex_position_04r" unit="mm" x="cathode_square_size*3.5" y="0" z="0" />
+		<position name="wirex_position_05r" unit="mm" x="cathode_square_size*4.5" y="0" z="0"/>
+		<position name="wirex_position_06r" unit="mm" x="cathode_square_size*5.5" y="0" z="0"/>
+		<position name="wirex_position_07r" unit="mm" x="cathode_square_size*6.5" y="0" z="0"/>
+		<position name="wirex_position_08r" unit="mm" x="cathode_square_size*7.5" y="0" z="0"/>
+		<position name="wirex_position_09r" unit="mm" x="cathode_square_size*8.5" y="0" z="0"/>
+		<position name="wirex_position_10r" unit="mm" x="cathode_square_size*9.5" y="0" z="0"/>
+		<position name="wirex_position_11r" unit="mm" x="cathode_square_size*10.5" y="0" z="0"/>
+		<position name="wirex_position_12r" unit="mm" x="cathode_square_size*11.5" y="0" z="0"/>
+        <position name="wirex_position_01l" unit="mm" x="-cathode_square_size*0.5" y="0" z="0"/>
+		<position name="wirex_position_02l" unit="mm" x="-cathode_square_size*1.5" y="0" z="0"/>
+		<position name="wirex_position_03l" unit="mm" x="-cathode_square_size*2.5" y="0" z="0"/>
+		<position name="wirex_position_04l" unit="mm" x="-cathode_square_size*3.5" y="0" z="0"/>
+		<position name="wirex_position_05l" unit="mm" x="-cathode_square_size*4.5" y="0" z="0"/>
+		<position name="wirex_position_06l" unit="mm" x="-cathode_square_size*5.5" y="0" z="0"/>
+		<position name="wirex_position_07l" unit="mm" x="-cathode_square_size*6.5" y="0" z="0"/>
+		<position name="wirex_position_08l" unit="mm" x="-cathode_square_size*7.5" y="0" z="0"/>
+		<position name="wirex_position_09l" unit="mm" x="-cathode_square_size*8.5" y="0" z="0"/>
+		<position name="wirex_position_10l" unit="mm" x="-cathode_square_size*9.5" y="0" z="0"/>
+		<position name="wirex_position_11l" unit="mm" x="-cathode_square_size*10.5" y="0" z="0"/>
+		<position name="wirex_position_12l" unit="mm" x="-cathode_square_size*11.5" y="0" z="0"/>
+
+        <!--Sample -->
+		<constant name="sampleXSize" value="245"/>
+		<constant name="sampleYSize" value="245"/>
+		<constant name="sample_thickness" value="1"/>
+		<constant name="gas_length" value="VesselLength-vessel_thickness" />
+
+		<!-- Upper Vessel definitions -->
+		<constant name="UpperVesselLength" value="105" />	<!--in mm's -->
+        <!-- Z Positions -->
+
+		<constant name="mylar_ZPosition" value="VesselLength+0.5*mylar_thickness"/>
+		<constant name="window_ZPosition" value="VesselLength-0.5*window_thickness"/>
+        <constant name="sample_ZPosition" value="VesselLength+0.5*sample_thickness"/>
+        <constant name="readout_ZPosition" value="vessel_thickness-0.5*readout_thickness" />
+
+		<position name="mylar_position" unit="mm" x="0" y="0" z="mylar_ZPosition"/>
+		<position name="sample_position" unit="mm" x="0" y="0" z="sample_ZPosition"/>
+        <position name="readout_position" unit="mm" x="0" y="0" z="readout_ZPosition" />
+        <position name="window_position" unit="mm" x="0" y="0" z="window_ZPosition" />
+        <position name="null_position" unit="mm" x="0" y="0" z="0" />
+
+		<constant name="gasUpperVesselLength" value="UpperVesselLength-vessel_thickness+window_thickness+mylar_thickness"/>
+
+       <!--Rotations -->
+
+       <rotation name="RotateY90" unit="deg" x="0" y="90" z="0"/>
+       <rotation name="RotateXY90" unit="deg" x="90" y="0" z="90"/>
+       <rotation name="RotateYZ270" unit="deg" x="0" y="90" z="90"/>
+
+    </define>
+
+    &materials;
+
+    &geometry;
+
+    <setup name="Default" version="1.0">
+        <world ref="World"/>
+    </setup>
+
+</gdml>

--- a/alphacamm-geometry/setup.gdml
+++ b/alphacamm-geometry/setup.gdml
@@ -3,7 +3,7 @@
 
 <!DOCTYPE gdml [
 <!ENTITY geometry SYSTEM "geometry.gdml">
-<!ENTITY materials SYSTEM "https://sultan.unizar.es/materials/materials.xml">
+<!ENTITY materials SYSTEM "https://rest-for-physics.github.io/materials/rest.xml">
 ]>
 
 

--- a/alphacamm-geometry/setup.gdml
+++ b/alphacamm-geometry/setup.gdml
@@ -39,7 +39,7 @@
         <constant name="windowYSize" value="250"/>
         <constant name="window_thickness" value="5"/>
 		<constant name="cathode_square_size" value="10"/>
-		<constant name="cathode_square_width" value="1"/>
+		<constant name="cathode_square_width" value="0.1"/>
 
         <position name="wirey_position_01r" unit="mm" x="0"  y="cathode_square_size*0.5" z="0"/>
 		<position name="wirey_position_02r" unit="mm" x="0"  y="cathode_square_size*1.5" z="0"/>

--- a/alphacamm-geometry/setup.gdml
+++ b/alphacamm-geometry/setup.gdml
@@ -10,14 +10,6 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
 
 <!-- Definition of global variables -->
-        
-    <!-- Just an example of a simple cylinder geometry file : setup.gdml
-         This file just defines de parameters of the geometry.
-         The geometry it is defined in geometry/BoxGeometry.gdml
-         The materials are defined in geometry/materials.xml
-         Author :  G. Luzon    Date :Nov-2016     Edit :  A. Quintana  Date : Dic-2021
-    -->
-
 <!-- All values should be in mm -->
 
      <define>
@@ -32,95 +24,95 @@
        <!-- vessel definitions -->
 
         <constant name="vessel_thickness" value="5" />   <!--in mm's -->
-	<constant name="VesselRadius" value="193" />
-	<constant name="VesselLength" value="110" />
+		<constant name="VesselRadius" value="193" />
+		<constant name="VesselLength" value="110" />
 
-	<!-- Micromegas variables -->
+		<!-- Micromegas variables -->
 
     	<constant name="readout_thickness" value="1"/>
         <constant name="readout_size" value="250"/>
 
         <!--Window/Cathode on top of the chamber  -->
 
-	<constant name="mylar_thickness" value="0.002"/>
+		<constant name="mylar_thickness" value="0.002"/>
         <constant name="windowXSize" value="250"/>
         <constant name="windowYSize" value="250"/>
         <constant name="window_thickness" value="5"/>
-	<constant name="cathode_square_size" value="10"/>
-	<constant name="cathode_square_width" value="1"/>
+		<constant name="cathode_square_size" value="10"/>
+		<constant name="cathode_square_width" value="1"/>
 
         <position name="wirey_position_01r" unit="mm" x="0"  y="cathode_square_size*0.5" z="0"/>
-	<position name="wirey_position_02r" unit="mm" x="0"  y="cathode_square_size*1.5" z="0"/>
-	<position name="wirey_position_03r" unit="mm" x="0" y="cathode_square_size*2.5" z="0"/>
-	<position name="wirey_position_04r" unit="mm" x="0" y="cathode_square_size*3.5" z="0" />
-	<position name="wirey_position_05r" unit="mm" x="0" y="cathode_square_size*4.5" z="0"/>
-	<position name="wirey_position_06r" unit="mm" x="0" y="cathode_square_size*5.5" z="0"/>
-	<position name="wirey_position_07r" unit="mm" x="0" y="cathode_square_size*6.5" z="0"/>
-	<position name="wirey_position_08r" unit="mm" x="0" y="cathode_square_size*7.5" z="0"/>
-	<position name="wirey_position_09r" unit="mm" x="0" y="cathode_square_size*8.5" z="0"/>
-	<position name="wirey_position_10r" unit="mm" x="0" y="cathode_square_size*9.5" z="0"/>
-	<position name="wirey_position_11r" unit="mm" x="0" y="cathode_square_size*10.5" z="0"/>
-	<position name="wirey_position_12r" unit="mm" x="0" y="cathode_square_size*11.5" z="0"/>
+		<position name="wirey_position_02r" unit="mm" x="0"  y="cathode_square_size*1.5" z="0"/>
+		<position name="wirey_position_03r" unit="mm" x="0" y="cathode_square_size*2.5" z="0"/>
+		<position name="wirey_position_04r" unit="mm" x="0" y="cathode_square_size*3.5" z="0" />
+		<position name="wirey_position_05r" unit="mm" x="0" y="cathode_square_size*4.5" z="0"/>
+		<position name="wirey_position_06r" unit="mm" x="0" y="cathode_square_size*5.5" z="0"/>
+		<position name="wirey_position_07r" unit="mm" x="0" y="cathode_square_size*6.5" z="0"/>
+		<position name="wirey_position_08r" unit="mm" x="0" y="cathode_square_size*7.5" z="0"/>
+		<position name="wirey_position_09r" unit="mm" x="0" y="cathode_square_size*8.5" z="0"/>
+		<position name="wirey_position_10r" unit="mm" x="0" y="cathode_square_size*9.5" z="0"/>
+		<position name="wirey_position_11r" unit="mm" x="0" y="cathode_square_size*10.5" z="0"/>
+		<position name="wirey_position_12r" unit="mm" x="0" y="cathode_square_size*11.5" z="0"/>
         <position name="wirey_position_01l" unit="mm" x="0" y="-cathode_square_size*0.5" z="0"/>
-	<position name="wirey_position_02l" unit="mm" x="0" y="-cathode_square_size*1.5" z="0"/>
-	<position name="wirey_position_03l" unit="mm" x="0" y="-cathode_square_size*2.5" z="0"/>
-	<position name="wirey_position_04l" unit="mm" x="0" y="-cathode_square_size*3.5" z="0"/>
-	<position name="wirey_position_05l" unit="mm" x="0" y="-cathode_square_size*4.5" z="0"/>
-	<position name="wirey_position_06l" unit="mm" x="0" y="-cathode_square_size*5.5" z="0"/>
-	<position name="wirey_position_07l" unit="mm" x="0" y="-cathode_square_size*6.5" z="0"/>
-	<position name="wirey_position_08l" unit="mm" x="0" y="-cathode_square_size*7.5" z="0"/>
-	<position name="wirey_position_09l" unit="mm" x="0" y="-cathode_square_size*8.5" z="0"/>
-	<position name="wirey_position_10l" unit="mm" x="0" y="-cathode_square_size*9.5" z="0"/>
-	<position name="wirey_position_11l" unit="mm" x="0" y="-cathode_square_size*10.5" z="0"/>
-	<position name="wirey_position_12l" unit="mm" x="0" y="-cathode_square_size*11.5" z="0"/>
+		<position name="wirey_position_02l" unit="mm" x="0" y="-cathode_square_size*1.5" z="0"/>
+		<position name="wirey_position_03l" unit="mm" x="0" y="-cathode_square_size*2.5" z="0"/>
+		<position name="wirey_position_04l" unit="mm" x="0" y="-cathode_square_size*3.5" z="0"/>
+		<position name="wirey_position_05l" unit="mm" x="0" y="-cathode_square_size*4.5" z="0"/>
+		<position name="wirey_position_06l" unit="mm" x="0" y="-cathode_square_size*5.5" z="0"/>
+		<position name="wirey_position_07l" unit="mm" x="0" y="-cathode_square_size*6.5" z="0"/>
+		<position name="wirey_position_08l" unit="mm" x="0" y="-cathode_square_size*7.5" z="0"/>
+		<position name="wirey_position_09l" unit="mm" x="0" y="-cathode_square_size*8.5" z="0"/>
+		<position name="wirey_position_10l" unit="mm" x="0" y="-cathode_square_size*9.5" z="0"/>
+		<position name="wirey_position_11l" unit="mm" x="0" y="-cathode_square_size*10.5" z="0"/>
+		<position name="wirey_position_12l" unit="mm" x="0" y="-cathode_square_size*11.5" z="0"/>
 	
-	<position name="wirex_position_01r" unit="mm" x="cathode_square_size*0.5"  y="0" z="0"/>
-	<position name="wirex_position_02r" unit="mm" x="cathode_square_size*1.5"  y="0" z="0"/>
-	<position name="wirex_position_03r" unit="mm" x="cathode_square_size*2.5" y="0" z="0"/>
-	<position name="wirex_position_04r" unit="mm" x="cathode_square_size*3.5" y="0" z="0" />
-	<position name="wirex_position_05r" unit="mm" x="cathode_square_size*4.5" y="0" z="0"/>
-	<position name="wirex_position_06r" unit="mm" x="cathode_square_size*5.5" y="0" z="0"/>
-	<position name="wirex_position_07r" unit="mm" x="cathode_square_size*6.5" y="0" z="0"/>
-	<position name="wirex_position_08r" unit="mm" x="cathode_square_size*7.5" y="0" z="0"/>
-	<position name="wirex_position_09r" unit="mm" x="cathode_square_size*8.5" y="0" z="0"/>
-	<position name="wirex_position_10r" unit="mm" x="cathode_square_size*9.5" y="0" z="0"/>
-	<position name="wirex_position_11r" unit="mm" x="cathode_square_size*10.5" y="0" z="0"/>
-	<position name="wirex_position_12r" unit="mm" x="cathode_square_size*11.5" y="0" z="0"/>
+		<position name="wirex_position_01r" unit="mm" x="cathode_square_size*0.5"  y="0" z="0"/>
+		<position name="wirex_position_02r" unit="mm" x="cathode_square_size*1.5"  y="0" z="0"/>
+		<position name="wirex_position_03r" unit="mm" x="cathode_square_size*2.5" y="0" z="0"/>
+		<position name="wirex_position_04r" unit="mm" x="cathode_square_size*3.5" y="0" z="0" />
+		<position name="wirex_position_05r" unit="mm" x="cathode_square_size*4.5" y="0" z="0"/>
+		<position name="wirex_position_06r" unit="mm" x="cathode_square_size*5.5" y="0" z="0"/>
+		<position name="wirex_position_07r" unit="mm" x="cathode_square_size*6.5" y="0" z="0"/>
+		<position name="wirex_position_08r" unit="mm" x="cathode_square_size*7.5" y="0" z="0"/>
+		<position name="wirex_position_09r" unit="mm" x="cathode_square_size*8.5" y="0" z="0"/>
+		<position name="wirex_position_10r" unit="mm" x="cathode_square_size*9.5" y="0" z="0"/>
+		<position name="wirex_position_11r" unit="mm" x="cathode_square_size*10.5" y="0" z="0"/>
+		<position name="wirex_position_12r" unit="mm" x="cathode_square_size*11.5" y="0" z="0"/>
         <position name="wirex_position_01l" unit="mm" x="-cathode_square_size*0.5" y="0" z="0"/>
-	<position name="wirex_position_02l" unit="mm" x="-cathode_square_size*1.5" y="0" z="0"/>
-	<position name="wirex_position_03l" unit="mm" x="-cathode_square_size*2.5" y="0" z="0"/>
-	<position name="wirex_position_04l" unit="mm" x="-cathode_square_size*3.5" y="0" z="0"/>
-	<position name="wirex_position_05l" unit="mm" x="-cathode_square_size*4.5" y="0" z="0"/>
-	<position name="wirex_position_06l" unit="mm" x="-cathode_square_size*5.5" y="0" z="0"/>
-	<position name="wirex_position_07l" unit="mm" x="-cathode_square_size*6.5" y="0" z="0"/>
-	<position name="wirex_position_08l" unit="mm" x="-cathode_square_size*7.5" y="0" z="0"/>
-	<position name="wirex_position_09l" unit="mm" x="-cathode_square_size*8.5" y="0" z="0"/>
-	<position name="wirex_position_10l" unit="mm" x="-cathode_square_size*9.5" y="0" z="0"/>
-	<position name="wirex_position_11l" unit="mm" x="-cathode_square_size*10.5" y="0" z="0"/>
-	<position name="wirex_position_12l" unit="mm" x="-cathode_square_size*11.5" y="0" z="0"/>
+		<position name="wirex_position_02l" unit="mm" x="-cathode_square_size*1.5" y="0" z="0"/>
+		<position name="wirex_position_03l" unit="mm" x="-cathode_square_size*2.5" y="0" z="0"/>
+		<position name="wirex_position_04l" unit="mm" x="-cathode_square_size*3.5" y="0" z="0"/>
+		<position name="wirex_position_05l" unit="mm" x="-cathode_square_size*4.5" y="0" z="0"/>
+		<position name="wirex_position_06l" unit="mm" x="-cathode_square_size*5.5" y="0" z="0"/>
+		<position name="wirex_position_07l" unit="mm" x="-cathode_square_size*6.5" y="0" z="0"/>
+		<position name="wirex_position_08l" unit="mm" x="-cathode_square_size*7.5" y="0" z="0"/>
+		<position name="wirex_position_09l" unit="mm" x="-cathode_square_size*8.5" y="0" z="0"/>
+		<position name="wirex_position_10l" unit="mm" x="-cathode_square_size*9.5" y="0" z="0"/>
+		<position name="wirex_position_11l" unit="mm" x="-cathode_square_size*10.5" y="0" z="0"/>
+		<position name="wirex_position_12l" unit="mm" x="-cathode_square_size*11.5" y="0" z="0"/>
 
         <!--Sample -->
-	<constant name="sampleXSize" value="245"/>
-	<constant name="sampleYSize" value="245"/>
-	<constant name="sample_thickness" value="1"/>
-	<constant name="gas_length" value="VesselLength-vessel_thickness" />
+		<constant name="sampleXSize" value="245"/>
+		<constant name="sampleYSize" value="245"/>
+		<constant name="sample_thickness" value="1"/>
+		<constant name="gas_length" value="VesselLength-vessel_thickness" />
 
-	<!-- Upper Vessel definitions -->
-	<constant name="UpperVesselLength" value="105" />	<!--in mm's -->
+		<!-- Upper Vessel definitions -->
+		<constant name="UpperVesselLength" value="105" />	<!--in mm's -->
         <!-- Z Positions -->
 
-	<constant name="mylar_ZPosition" value="VesselLength+0.5*mylar_thickness"/>
-	<constant name="window_ZPosition" value="VesselLength-0.5*window_thickness"/>
+		<constant name="mylar_ZPosition" value="VesselLength+0.5*mylar_thickness"/>
+		<constant name="window_ZPosition" value="VesselLength-0.5*window_thickness"/>
         <constant name="sample_ZPosition" value="VesselLength+0.5*sample_thickness"/>
         <constant name="readout_ZPosition" value="vessel_thickness-0.5*readout_thickness" />
 
-	<position name="mylar_position" unit="mm" x="0" y="0" z="mylar_ZPosition"/>
-	<position name="sample_position" unit="mm" x="0" y="0" z="sample_ZPosition"/>
+		<position name="mylar_position" unit="mm" x="0" y="0" z="mylar_ZPosition"/>
+		<position name="sample_position" unit="mm" x="0" y="0" z="sample_ZPosition"/>
         <position name="readout_position" unit="mm" x="0" y="0" z="readout_ZPosition" />
         <position name="window_position" unit="mm" x="0" y="0" z="window_ZPosition" />
         <position name="null_position" unit="mm" x="0" y="0" z="0" />
 
-	<constant name="gasUpperVesselLength" value="UpperVesselLength-vessel_thickness+window_thickness+mylar_thickness"/>
+		<constant name="gasUpperVesselLength" value="UpperVesselLength-vessel_thickness+window_thickness+mylar_thickness"/>
 
        <!--Rotations -->
 

--- a/alphacamm-geometry/setup.gdml
+++ b/alphacamm-geometry/setup.gdml
@@ -13,7 +13,7 @@
 <!-- All values should be in mm -->
 
      <define>
-       <variable name="world_size" value="20000" />
+       <variable name="world_size" value="20000"/>
        <!-- The TPC gas target -->
        <variable name="targetGasDensity" value="1.61"/>
        <variable name="quencherFraction" value="0.02"/>
@@ -21,105 +21,38 @@
        <variable name="gasTemperature" value="300"/> <!-- K -->
        <variable name="gasPressure" value="1.05"/> <!-- bar -->
 
-       <!-- vessel definitions -->
+		<!-- Vessel -->
+        <constant name="vessel_thickness" value="5"/>   <!--in mm's -->
+		<constant name="vessel_radius" value="200"/> <!--internal radius-->
+		<constant name="vessel_inner_length" value="135"/>
 
-        <constant name="vessel_thickness" value="5" />   <!--in mm's -->
-		<constant name="VesselRadius" value="193" />
-		<constant name="VesselLength" value="110" />
-
-		<!-- Micromegas variables -->
-
+		<!-- Micromegas -->
     	<constant name="readout_thickness" value="1"/>
         <constant name="readout_size" value="250"/>
 
-        <!--Window/Cathode on top of the chamber  -->
+       	<!--Gas (sensitive volume) -->
+		<constant name="gas_length" value="60"/> 
 
-		<constant name="mylar_thickness" value="0.002"/>
-        <constant name="windowXSize" value="250"/>
-        <constant name="windowYSize" value="250"/>
-        <constant name="window_thickness" value="5"/>
-		<constant name="cathode_square_size" value="10"/>
-		<constant name="cathode_square_width" value="0.1"/>
-
-        <position name="wirey_position_01r" unit="mm" x="0"  y="cathode_square_size*0.5" z="0"/>
-		<position name="wirey_position_02r" unit="mm" x="0"  y="cathode_square_size*1.5" z="0"/>
-		<position name="wirey_position_03r" unit="mm" x="0" y="cathode_square_size*2.5" z="0"/>
-		<position name="wirey_position_04r" unit="mm" x="0" y="cathode_square_size*3.5" z="0" />
-		<position name="wirey_position_05r" unit="mm" x="0" y="cathode_square_size*4.5" z="0"/>
-		<position name="wirey_position_06r" unit="mm" x="0" y="cathode_square_size*5.5" z="0"/>
-		<position name="wirey_position_07r" unit="mm" x="0" y="cathode_square_size*6.5" z="0"/>
-		<position name="wirey_position_08r" unit="mm" x="0" y="cathode_square_size*7.5" z="0"/>
-		<position name="wirey_position_09r" unit="mm" x="0" y="cathode_square_size*8.5" z="0"/>
-		<position name="wirey_position_10r" unit="mm" x="0" y="cathode_square_size*9.5" z="0"/>
-		<position name="wirey_position_11r" unit="mm" x="0" y="cathode_square_size*10.5" z="0"/>
-		<position name="wirey_position_12r" unit="mm" x="0" y="cathode_square_size*11.5" z="0"/>
-        <position name="wirey_position_01l" unit="mm" x="0" y="-cathode_square_size*0.5" z="0"/>
-		<position name="wirey_position_02l" unit="mm" x="0" y="-cathode_square_size*1.5" z="0"/>
-		<position name="wirey_position_03l" unit="mm" x="0" y="-cathode_square_size*2.5" z="0"/>
-		<position name="wirey_position_04l" unit="mm" x="0" y="-cathode_square_size*3.5" z="0"/>
-		<position name="wirey_position_05l" unit="mm" x="0" y="-cathode_square_size*4.5" z="0"/>
-		<position name="wirey_position_06l" unit="mm" x="0" y="-cathode_square_size*5.5" z="0"/>
-		<position name="wirey_position_07l" unit="mm" x="0" y="-cathode_square_size*6.5" z="0"/>
-		<position name="wirey_position_08l" unit="mm" x="0" y="-cathode_square_size*7.5" z="0"/>
-		<position name="wirey_position_09l" unit="mm" x="0" y="-cathode_square_size*8.5" z="0"/>
-		<position name="wirey_position_10l" unit="mm" x="0" y="-cathode_square_size*9.5" z="0"/>
-		<position name="wirey_position_11l" unit="mm" x="0" y="-cathode_square_size*10.5" z="0"/>
-		<position name="wirey_position_12l" unit="mm" x="0" y="-cathode_square_size*11.5" z="0"/>
-	
-		<position name="wirex_position_01r" unit="mm" x="cathode_square_size*0.5"  y="0" z="0"/>
-		<position name="wirex_position_02r" unit="mm" x="cathode_square_size*1.5"  y="0" z="0"/>
-		<position name="wirex_position_03r" unit="mm" x="cathode_square_size*2.5" y="0" z="0"/>
-		<position name="wirex_position_04r" unit="mm" x="cathode_square_size*3.5" y="0" z="0" />
-		<position name="wirex_position_05r" unit="mm" x="cathode_square_size*4.5" y="0" z="0"/>
-		<position name="wirex_position_06r" unit="mm" x="cathode_square_size*5.5" y="0" z="0"/>
-		<position name="wirex_position_07r" unit="mm" x="cathode_square_size*6.5" y="0" z="0"/>
-		<position name="wirex_position_08r" unit="mm" x="cathode_square_size*7.5" y="0" z="0"/>
-		<position name="wirex_position_09r" unit="mm" x="cathode_square_size*8.5" y="0" z="0"/>
-		<position name="wirex_position_10r" unit="mm" x="cathode_square_size*9.5" y="0" z="0"/>
-		<position name="wirex_position_11r" unit="mm" x="cathode_square_size*10.5" y="0" z="0"/>
-		<position name="wirex_position_12r" unit="mm" x="cathode_square_size*11.5" y="0" z="0"/>
-        <position name="wirex_position_01l" unit="mm" x="-cathode_square_size*0.5" y="0" z="0"/>
-		<position name="wirex_position_02l" unit="mm" x="-cathode_square_size*1.5" y="0" z="0"/>
-		<position name="wirex_position_03l" unit="mm" x="-cathode_square_size*2.5" y="0" z="0"/>
-		<position name="wirex_position_04l" unit="mm" x="-cathode_square_size*3.5" y="0" z="0"/>
-		<position name="wirex_position_05l" unit="mm" x="-cathode_square_size*4.5" y="0" z="0"/>
-		<position name="wirex_position_06l" unit="mm" x="-cathode_square_size*5.5" y="0" z="0"/>
-		<position name="wirex_position_07l" unit="mm" x="-cathode_square_size*6.5" y="0" z="0"/>
-		<position name="wirex_position_08l" unit="mm" x="-cathode_square_size*7.5" y="0" z="0"/>
-		<position name="wirex_position_09l" unit="mm" x="-cathode_square_size*8.5" y="0" z="0"/>
-		<position name="wirex_position_10l" unit="mm" x="-cathode_square_size*9.5" y="0" z="0"/>
-		<position name="wirex_position_11l" unit="mm" x="-cathode_square_size*10.5" y="0" z="0"/>
-		<position name="wirex_position_12l" unit="mm" x="-cathode_square_size*11.5" y="0" z="0"/>
-
-        <!--Sample -->
+		<!--Sample -->
 		<constant name="sampleXSize" value="245"/>
 		<constant name="sampleYSize" value="245"/>
 		<constant name="sample_thickness" value="1"/>
-		<constant name="gas_length" value="VesselLength-vessel_thickness" />
 
-		<!-- Upper Vessel definitions -->
-		<constant name="UpperVesselLength" value="105" />	<!--in mm's -->
+        <!--Window/Cathode in the middle of the chamber  -->
+		<constant name="cathode_radius" value="200"/>
+		<constant name="cathode_thickness" value="0.5"/>
+
+		<!--Gas below cathode -->
+		<constant name="gas_below_length" value="vessel_inner_length-gas_length"/> 
+
         <!-- Z Positions -->
-
-		<constant name="mylar_ZPosition" value="VesselLength+0.5*mylar_thickness"/>
-		<constant name="window_ZPosition" value="VesselLength-0.5*window_thickness"/>
-        <constant name="sample_ZPosition" value="VesselLength+0.5*sample_thickness"/>
-        <constant name="readout_ZPosition" value="vessel_thickness-0.5*readout_thickness" />
-
-		<position name="mylar_position" unit="mm" x="0" y="0" z="mylar_ZPosition"/>
-		<position name="sample_position" unit="mm" x="0" y="0" z="sample_ZPosition"/>
-        <position name="readout_position" unit="mm" x="0" y="0" z="readout_ZPosition" />
-        <position name="window_position" unit="mm" x="0" y="0" z="window_ZPosition" />
-        <position name="null_position" unit="mm" x="0" y="0" z="0" />
-
-		<constant name="gasUpperVesselLength" value="UpperVesselLength-vessel_thickness+window_thickness+mylar_thickness"/>
-
-       <!--Rotations -->
-
-       <rotation name="RotateY90" unit="deg" x="0" y="90" z="0"/>
-       <rotation name="RotateXY90" unit="deg" x="90" y="0" z="90"/>
-       <rotation name="RotateYZ270" unit="deg" x="0" y="90" z="90"/>
-
+		<constant name="vesselTopcover_ZPosition" value="0.5*gas_length+0.5*vessel_thickness"/>
+		<constant name="readout_ZPosition" value="0.5*gas_length+0.5*readout_thickness"/>
+		<constant name="cathode_ZPosition" value="-0.5*gas_length-0.5*cathode_thickness"/>
+		<constant name="sample_ZPosition" value="-0.5*gas_length+0.5*sample_thickness"/>
+		<constant name="gasbelow_ZPosition" value="-0.5*gas_length-0.5*gas_below_length"/>
+		<constant name="vesselBottomcover_ZPosition" value="-0.5*gas_length-gas_below_length-0.5*vessel_thickness"/>
+		<constant name="vessel_ZPosition" value="0.5*gas_length-0.5*vessel_inner_length"/>
     </define>
 
     &materials;

--- a/alphacamm-geometry/setup.gdml
+++ b/alphacamm-geometry/setup.gdml
@@ -46,13 +46,22 @@
 		<constant name="gas_below_length" value="vessel_inner_length-gas_length"/> 
 
         <!-- Z Positions -->
-		<constant name="vesselTopcover_ZPosition" value="0.5*gas_length+0.5*vessel_thickness"/>
+		<!--<constant name="vesselTopcover_ZPosition" value="0.5*gas_length+0.5*vessel_thickness"/>
 		<constant name="readout_ZPosition" value="0.5*gas_length+0.5*readout_thickness"/>
 		<constant name="cathode_ZPosition" value="-0.5*gas_length-0.5*cathode_thickness"/>
 		<constant name="sample_ZPosition" value="-0.5*gas_length+0.5*sample_thickness"/>
 		<constant name="gasbelow_ZPosition" value="-0.5*gas_length-0.5*gas_below_length"/>
 		<constant name="vesselBottomcover_ZPosition" value="-0.5*gas_length-gas_below_length-0.5*vessel_thickness"/>
-		<constant name="vessel_ZPosition" value="0.5*gas_length-0.5*vessel_inner_length"/>
+		<constant name="vessel_ZPosition" value="0.5*gas_length-0.5*vessel_inner_length"/>-->
+
+		<constant name="vesselTopcover_ZPosition" value="0.5*vessel_thickness+readout_thicnkess"/>
+		<constant name="readout_ZPosition" value="0.5*readout_thickness"/>
+		<constant name="gas_ZPosition" value="-0.5*gas_length"/>
+		<constant name="cathode_ZPosition" value="-gas_length-0.5*cathode_thickness"/>
+		<constant name="gasbelow_ZPosition" value="-gas_length-cathode_thickness-0.5*gas_below_length"/>
+		<constant name="vesselBottomcover_ZPosition" value="-gas_length-cathode_thickness-gas_below_length-0.5*vessel_thickness"/>
+		<constant name="vessel_ZPosition" value="-0.5*vessel_inner_length"/>
+
     </define>
 
     &materials;

--- a/alphacamm-geometry/setup.gdml
+++ b/alphacamm-geometry/setup.gdml
@@ -33,11 +33,6 @@
        	<!--Gas (sensitive volume) -->
 		<constant name="gas_length" value="60"/> 
 
-		<!--Sample -->
-		<constant name="sampleXSize" value="245"/>
-		<constant name="sampleYSize" value="245"/>
-		<constant name="sample_thickness" value="1"/>
-
         <!--Window/Cathode in the middle of the chamber  -->
 		<constant name="cathode_radius" value="200"/>
 		<constant name="cathode_thickness" value="0.5"/>
@@ -45,15 +40,12 @@
 		<!--Gas below cathode -->
 		<constant name="gas_below_length" value="vessel_inner_length-gas_length"/> 
 
-        <!-- Z Positions -->
-		<!--<constant name="vesselTopcover_ZPosition" value="0.5*gas_length+0.5*vessel_thickness"/>
-		<constant name="readout_ZPosition" value="0.5*gas_length+0.5*readout_thickness"/>
-		<constant name="cathode_ZPosition" value="-0.5*gas_length-0.5*cathode_thickness"/>
-		<constant name="sample_ZPosition" value="-0.5*gas_length+0.5*sample_thickness"/>
-		<constant name="gasbelow_ZPosition" value="-0.5*gas_length-0.5*gas_below_length"/>
-		<constant name="vesselBottomcover_ZPosition" value="-0.5*gas_length-gas_below_length-0.5*vessel_thickness"/>
-		<constant name="vessel_ZPosition" value="0.5*gas_length-0.5*vessel_inner_length"/>-->
+		<!--Sample -->
+		<constant name="sampleXSize" value="100"/>
+		<constant name="sampleYSize" value="50"/>
+		<constant name="sample_thickness" value="5"/>
 
+        <!-- Z Positions (relative to readout)-->
 		<constant name="vesselTopcover_ZPosition" value="0.5*vessel_thickness+readout_thicnkess"/>
 		<constant name="readout_ZPosition" value="0.5*readout_thickness"/>
 		<constant name="gas_ZPosition" value="-0.5*gas_length"/>
@@ -61,6 +53,11 @@
 		<constant name="gasbelow_ZPosition" value="-gas_length-cathode_thickness-0.5*gas_below_length"/>
 		<constant name="vesselBottomcover_ZPosition" value="-gas_length-cathode_thickness-gas_below_length-0.5*vessel_thickness"/>
 		<constant name="vessel_ZPosition" value="-0.5*vessel_inner_length"/>
+
+		<!--sample position: relative to gas-->
+    	<constant name="sample_ZPosition" value="-0.5*gas_length+0.5*sample_thickness"/>
+    	<constant name="sample_XPosition" value="0"/>
+    	<constant name="sample_YPosition" value="0"/>
 
     </define>
 


### PR DESCRIPTION
WORK IN PROGRESS, DON'T MERGE

- The remote materials file `https://sultan.unizar.es/materials/materials.xml` don't work, I replace it with `https://rest-for-physics.github.io/materials/rest.xml` 
- Including explicit units
- In the last version of the geometry (October 2023) I changed the width of the grid in the cathode to 0.1 mm so I have included this change here

This is the status of the geometry right now:

![imagen](https://github.com/user-attachments/assets/2e5b26ea-1e85-4a9c-a364-95806762216a)

Tasks to update the geometry:
- [x] Check materials?
- [x] Remove the grid (or keep the old geometry and make a new one without grid)
- [x] Reduce drift distance: is this something that is going to change from time to time? We can make different versions of the geometry with different drift distances or make it variable

